### PR TITLE
Nginx port and environment options

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,7 @@
 !.env
 !docker-compose.yml
 !grafana.env
+!nginx.env
 
 !start_point_check.rb
 !start_point_checker.rb

--- a/cyber-dojo
+++ b/cyber-dojo
@@ -61,6 +61,10 @@ delegate_to_commander()
 {
   local my_dir="$( cd "$( dirname "${0}" )" && pwd )"
 
+  if [ -f ${my_dir}/nginx.env ] && [ "${is_up}" == 'true' ];  then
+    local nginx_env_file="--volume=${my_dir}/nginx.env:/app/nginx.env"
+  fi
+
   if [ -f ${my_dir}/grafana.env ] && [ "${is_up}" == 'true' ];  then
     local grafana_env_file="--volume=${my_dir}/grafana.env:/app/grafana.env"
   fi
@@ -78,6 +82,7 @@ delegate_to_commander()
     --user=root \
     --volume=/var/run/docker.sock:/var/run/docker.sock \
     ${grafana_env_file} \
+    ${nginx_env_file} \
     ${cyber_dojo_commander} \
     /app/cyber-dojo.sh $*
 }

--- a/cyber-dojo.rb
+++ b/cyber-dojo.rb
@@ -227,6 +227,24 @@ end
 # $ ./cyber-dojo up
 #==========================================================
 
+def up_arg_int_ok(help, args, name)
+  integer_value = get_arg("--#{name}", args)
+  if integer_value.nil?
+    return true
+  end
+
+  if integer_value == ''
+    STDERR.puts "FAILED: missing argument value --#{name}=[???]"
+    return false
+  end
+
+  # TODO: Do we want to validate that it's an integer?
+
+  return true
+end
+
+# - - - - - - - - - - - - - - - - - - - - - - - - -
+
 def up_arg_ok(help, args, name)
   vol = get_arg("--#{name}", args)
   if vol.nil? || vol == name # handled in cyber-dojo.sh
@@ -268,7 +286,10 @@ def up
     '',
     minitab + '--custom=START-POINT     Specify the custom start-point.',
     minitab + "                         Defaults to a start-point named 'custom' created from",
-    minitab + '                         https://github.com/cyber-dojo/start-points-custom.git'
+    minitab + '                         https://github.com/cyber-dojo/start-points-custom.git',
+    '',
+    minitab + '--port=LISTEN-PORT       Specify port to listen on.',
+    minitab + "                         Defaults to 80"
   ]
 
   if ARGV[1] == '--help'
@@ -278,7 +299,7 @@ def up
 
   # unknown arguments?
   args = ARGV[1..-1]
-  knowns = ['languages','exercises','custom']
+  knowns = ['languages','exercises','custom','port']
   unknown = args.select do |arg|
     knowns.none? { |known| arg.start_with?('--' + known + '=') }
   end
@@ -291,6 +312,7 @@ def up
   exit failed unless up_arg_ok(help, args, 'languages')  # --languages=NAME
   exit failed unless up_arg_ok(help, args, 'exercises')  # --exercises=NAME
   exit failed unless up_arg_ok(help, args,    'custom')  # --custom=NAME
+  exit failed unless up_arg_int_ok(help, args,  'port')  # --port=PORT
 
   # cyber-dojo.sh does actual [up]
 end

--- a/cyber-dojo.sh
+++ b/cyber-dojo.sh
@@ -39,11 +39,13 @@ cyber_dojo_commander=${cyber_dojo_hub}/commander
 default_start_point_languages=languages
 default_start_point_exercises=exercises
 default_start_point_custom=custom
+default_nginx_port=80
 
 # set environment variables required by docker-compose.yml
 export CYBER_DOJO_START_POINT_LANGUAGES=${default_start_point_languages}
 export CYBER_DOJO_START_POINT_EXERCISES=${default_start_point_exercises}
 export CYBER_DOJO_START_POINT_CUSTOM=${default_start_point_custom}
+export CYBER_DOJO_NGINX_PORT=${default_nginx_port}
 export CYBER_DOJO_KATAS_DATA_CONTAINER=cyber-dojo-katas-DATA-CONTAINER
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -226,6 +228,10 @@ cyber_dojo_up()
     if [ "${name}" = "--custom" ] && [ "${value}" != '' ]; then
       export CYBER_DOJO_START_POINT_CUSTOM=${value}
     fi
+    # --port=listen-port
+    if [ "${name}" = "--port" ] && [ "${value}" != '' ]; then
+      export CYBER_DOJO_NGINX_PORT=${value}
+    fi
   done
 
   # create default start-points if necessary
@@ -265,6 +271,7 @@ cyber_dojo_up()
   echo "Using start-point --languages=${CYBER_DOJO_START_POINT_LANGUAGES}"
   echo "Using start-point --exercises=${CYBER_DOJO_START_POINT_EXERCISES}"
   echo "Using start-point --custom=${CYBER_DOJO_START_POINT_CUSTOM}"
+  echo "Listening on port ${CYBER_DOJO_NGINX_PORT}"
 
   # Bring up server with volumes
   # It seems a successful [docker-compose up] writes to stderr !?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     env_file:
       - /app/nginx.env
     ports:
-      - '80:80'
+      - ${CYBER_DOJO_NGINX_PORT}:80
 
   web:
     user: root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     restart: on-failure
     depends_on:
       - web
+    env_file:
+      - /app/nginx.env
     ports:
       - '80:80'
 

--- a/test/sh/test_up.sh
+++ b/test/sh/test_up.sh
@@ -35,7 +35,11 @@ Creates and starts the cyber-dojo server using named/default start-points
 
   --custom=START-POINT     Specify the custom start-point.
                            Defaults to a start-point named 'custom' created from
-                           https://github.com/cyber-dojo/start-points-custom.git"
+                           https://github.com/cyber-dojo/start-points-custom.git
+
+  --port=LISTEN-PORT       Specify port to listen on.
+                           Defaults to 80"
+  ${exe} up --help >${stdoutF} 2>${stderrF}
   ${exe} up --help >${stdoutF} 2>${stderrF}
   assertTrue $?
   assertEqualsStdout "${expected_stdout}"
@@ -100,6 +104,17 @@ test_up_missingExercises_prints_msg_to_sterr_and_exits_non_zero()
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+test_up_missingPort_prints_msg_to_sterr_and_exits_non_zero()
+{
+  local expected_stderr='FAILED: missing argument value --port=[???]'
+  ${exe} up --port= >${stdoutF} 2>${stderrF}
+  assertFalse $?
+  assertNoStdout
+  assertEqualsStderr "${expected_stderr}"
+}
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
 test_up_namedLanguagesDoesNotExist_prints_msg_to_sterr_and_exits_non_zero()
 {
   local expected_stderr='FAILED: start-point notExist does not exist'
@@ -149,13 +164,14 @@ test_up_namedExercisesIsNotExerciseType_prints_msg_to_sterr_and_exits_non_zero()
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-test_up_prints_msg_naming_default_start_points_exits_zero()
+test_up_prints_msg_naming_default_start_points_and_port_exits_zero()
 {
   ${exe} up >${stdoutF} 2>${stderrF}
   assertTrue $?
   local expected_stdout="Using start-point --languages=languages
 Using start-point --exercises=exercises
-Using start-point --custom=custom"
+Using start-point --custom=custom
+Listening on port 80"
   assertStdoutIncludes ${expected_stdout}
   assertNoStderr
   ${exe} down >${stdoutF} 2>${stderrF}
@@ -175,12 +191,31 @@ test_up_customStartPoint_prints_msg_saying_its_being_used_exits_zero()
 
   local expected_stdout="Using start-point --languages=languages
 Using start-point --exercises=exercises
-Using start-point --custom=${name}"
+Using start-point --custom=${name}
+Listening on port 80"
   assertStdoutIncludes ${expected_stdout}
   assertNoStderr
   ${exe} down >${stdoutF} 2>${stderrF}
   assertTrue $?
   ${exe} start-point rm ${name} >${stdoutF} 2>${stderrF}
+  assertTrue $?
+}
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+test_up_customPort_prints_msg_saying_its_being_used_exits_zero()
+{
+  local port=8462
+  ${exe} up --port=${port} >${stdoutF} 2>${stderrF}
+  assertTrue $?
+
+  local expected_stdout="Using start-point --languages=languages
+Using start-point --exercises=exercises
+Using start-point --custom=custom
+Listening on port ${port}"
+  assertStdoutIncludes ${expected_stdout}
+  assertNoStderr
+  ${exe} down >${stdoutF} 2>${stderrF}
   assertTrue $?
 }
 


### PR DESCRIPTION
As discussed in #9, this provides a `--port` option for cyber-dojo, as well as support for an _nginx.env_ file similar to the existing _grafana.env_.

The target use-case is to expose cyber-dojo running on a shared machine via https://github.com/jwilder/nginx-proxy. This proxy will publish any exposed port using name-based virtual hosting, according to a `VIRTUAL_HOST` environment variable set in the container.